### PR TITLE
More robust facebook login handler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,8 @@ test-oauth:
 test-accounts:
 	bash -c 'go test -timeout=30s github.com/RichardKnop/recall/accounts'
 
+test-facebook:
+	bash -c 'go test -timeout=60s github.com/RichardKnop/recall/facebook'
+
 test:
-	bash -c 'go list ./... | grep -v vendor | xargs -n1 go test -timeout=30s'
+	bash -c 'go list ./... | grep -v vendor | xargs -n1 go test -timeout=60s'

--- a/accounts/service_interface.go
+++ b/accounts/service_interface.go
@@ -27,7 +27,7 @@ type ServiceInterface interface {
 	ConfirmUser(user *User) error
 	FindPasswordResetByReference(reference string) (*PasswordReset, error)
 	ResetPassword(passwordReset *PasswordReset, password string) error
-	CreateFacebookUser(account *Account, facebookID string, userRequest *UserRequest) (*User, error)
+	GetOrCreateFacebookUser(account *Account, facebookID string, userRequest *UserRequest) (*User, error)
 	CreateSuperuser(account *Account, email, password string) (*User, error)
 
 	// Needed for the newRoutes to be able to register handlers

--- a/accounts/service_mock.go
+++ b/accounts/service_mock.go
@@ -339,8 +339,8 @@ func (_m *ServiceMock) ResetPassword(passwordReset *PasswordReset, password stri
 	return r0
 }
 
-// CreateFacebookUser ...
-func (_m *ServiceMock) CreateFacebookUser(account *Account, facebookID string, userRequest *UserRequest) (*User, error) {
+// GetOrCreateFacebookUser ...
+func (_m *ServiceMock) GetOrCreateFacebookUser(account *Account, facebookID string, userRequest *UserRequest) (*User, error) {
 	ret := _m.Called(account, facebookID, userRequest)
 
 	var r0 *User

--- a/facebook/login_test.go
+++ b/facebook/login_test.go
@@ -38,7 +38,7 @@ func (suite *FacebookTestSuite) TestLoginExistingUser() {
 	// Mock fetching profile data from facebook
 	suite.mockFacebookGetMe(fb.Result{
 		"id":         interface{}("facebook_id_2"),
-		"email":      interface{}("test@user"),
+		"email":      interface{}(suite.users[1].OauthUser.Username),
 		"first_name": interface{}("test_first_name_2"),
 		"last_name":  interface{}("test_last_name_2"),
 	}, nil)
@@ -67,12 +67,94 @@ func (suite *FacebookTestSuite) TestLoginExistingUser() {
 	// Fetch the logged in user
 	user := new(accounts.User)
 	notFound := suite.db.Preload("Account").Preload("OauthUser").
-		Preload("Role").Last(user).RecordNotFound()
+		Preload("Role.Permissions").First(user, suite.users[1].ID).RecordNotFound()
 	assert.False(suite.T(), notFound)
 
 	// The user should not have changed
 	assert.Equal(suite.T(), "test@user", user.OauthUser.Username)
 	assert.Equal(suite.T(), "facebook_id_2", user.FacebookID.String)
+	assert.Equal(suite.T(), "test_first_name_2", user.FirstName.String)
+	assert.Equal(suite.T(), "test_last_name_2", user.LastName.String)
+
+	// Fetch oauth tokens
+	accessToken := new(oauth.AccessToken)
+	assert.False(suite.T(), suite.db.First(accessToken).RecordNotFound())
+	refreshToken := new(oauth.RefreshToken)
+	assert.False(suite.T(), suite.db.First(refreshToken).RecordNotFound())
+
+	// Check the response body
+	expected, err := json.Marshal(&oauth.AccessTokenResponse{
+		ID:           accessToken.ID,
+		AccessToken:  accessToken.Token,
+		ExpiresIn:    3600,
+		TokenType:    oauth.TokenType,
+		Scope:        "read_write",
+		RefreshToken: refreshToken.Token,
+	})
+	if assert.NoError(suite.T(), err, "JSON marshalling failed") {
+		assert.Equal(suite.T(), string(expected), strings.TrimSpace(w.Body.String()))
+	}
+}
+
+func (suite *FacebookTestSuite) TestLoginUpdatesFacebookIDOfExistingUser() {
+	// Prepare a request
+	r, err := http.NewRequest("POST", "http://1.2.3.4/v1/facebook/login", nil)
+	assert.NoError(suite.T(), err, "Request setup should not get an error")
+	r.PostForm = url.Values{
+		"access_token": {"facebook_token"},
+		"scope":        {"read_write"},
+	}
+	r.SetBasicAuth("test_client_1", "test_secret")
+
+	// Check the routing
+	match := new(mux.RouteMatch)
+	suite.router.Match(r, match)
+	if assert.NotNil(suite.T(), match.Route) {
+		assert.Equal(suite.T(), "facebook_login", match.Route.GetName())
+	}
+
+	// Mock fetching profile data from facebook
+	suite.mockFacebookGetMe(fb.Result{
+		"id":         interface{}("user_facebook_id"),
+		"email":      interface{}(suite.users[1].OauthUser.Username),
+		"first_name": interface{}("Harold"),
+		"last_name":  interface{}("Finch"),
+	}, nil)
+
+	// Count before
+	var countBefore int
+	suite.db.Model(new(accounts.User)).Count(&countBefore)
+
+	// And serve the request
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, r)
+
+	// Check mock expectations were met
+	suite.adapterMock.AssertExpectations(suite.T())
+
+	// Check the status code
+	if !assert.Equal(suite.T(), 200, w.Code) {
+		log.Print(w.Body.String())
+	}
+
+	// Count after
+	var countAfter int
+	suite.db.Model(new(accounts.User)).Count(&countAfter)
+	assert.Equal(suite.T(), countBefore, countAfter)
+
+	// Fetch the updated user
+	user := new(accounts.User)
+	notFound := suite.db.Preload("Account").Preload("OauthUser").
+		Preload("Role.Permissions").First(user, suite.users[1].ID).RecordNotFound()
+	assert.False(suite.T(), notFound)
+
+	// And correct data was saved
+	assert.Equal(suite.T(), "test@user", user.OauthUser.Username)
+	assert.Equal(suite.T(), "Harold", user.FirstName.String)
+	assert.Equal(suite.T(), "Finch", user.LastName.String)
+	assert.Equal(suite.T(), "user_facebook_id", user.FacebookID.String)
+	assert.Equal(suite.T(), roles.User, user.Role.ID)
+	assert.True(suite.T(), user.Confirmed)
 
 	// Fetch oauth tokens
 	accessToken := new(oauth.AccessToken)
@@ -113,8 +195,8 @@ func (suite *FacebookTestSuite) TestLoginCreatesNewUser() {
 
 	// Mock fetching profile data from facebook
 	suite.mockFacebookGetMe(fb.Result{
-		"id":         interface{}("new_facebook_id"),
-		"email":      interface{}("test@user2"),
+		"id":         interface{}("newuser_facebook_id"),
+		"email":      interface{}("test@newuser"),
 		"first_name": interface{}("John"),
 		"last_name":  interface{}("Reese"),
 	}, nil)
@@ -143,15 +225,16 @@ func (suite *FacebookTestSuite) TestLoginCreatesNewUser() {
 	// Fetch the created user
 	user := new(accounts.User)
 	notFound := suite.db.Preload("Account").Preload("OauthUser").
-		Preload("Role").Last(user).RecordNotFound()
+		Preload("Role.Permissions").Last(user).RecordNotFound()
 	assert.False(suite.T(), notFound)
 
 	// And correct data was saved
-	assert.Equal(suite.T(), "test@user2", user.OauthUser.Username)
+	assert.Equal(suite.T(), "test@newuser", user.OauthUser.Username)
 	assert.Equal(suite.T(), "John", user.FirstName.String)
 	assert.Equal(suite.T(), "Reese", user.LastName.String)
-	assert.Equal(suite.T(), "new_facebook_id", user.FacebookID.String)
+	assert.Equal(suite.T(), "newuser_facebook_id", user.FacebookID.String)
 	assert.Equal(suite.T(), roles.User, user.Role.ID)
+	assert.True(suite.T(), user.Confirmed)
 
 	// Fetch oauth tokens
 	accessToken := new(oauth.AccessToken)
@@ -245,8 +328,8 @@ func (suite *FacebookTestSuite) TestLoginErrAccountMismatch() {
 	suite.mockFacebookGetMe(fb.Result{
 		"id":         interface{}("facebook_id_2"),
 		"email":      interface{}("test@user"),
-		"first_name": interface{}("test_first_name_2"),
-		"last_name":  interface{}("test_last_name_2"),
+		"first_name": interface{}("Harold"),
+		"last_name":  interface{}("Finch"),
 	}, nil)
 
 	// Count before


### PR DESCRIPTION
Made some changes while investigating the Facebook login problem.

After fetching the user data from Facebook we now do:

1) If user with such facebook ID already exists, just login
2) If user with such email already exists, set facebook ID, first name, last name, then login
3) Create a new user and login